### PR TITLE
Fix misspelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ var data = {
     "content": "New Task Content",
     "status": "Open"
     };
-var info = await Clickup.Tasks.cretae_task("list_id", data);
+var info = await Clickup.Tasks.create_task("list_id", data);
 
 console.log(info);
 ```

--- a/src/components/Tasks.js
+++ b/src/components/Tasks.js
@@ -9,7 +9,7 @@ var Tasks = function (token) {
  * @param {String} list_id List ID where task be created
  * @param {JSON} data Body request for Task
  */
-Tasks.prototype.cretae_task = function (list_id, data) {
+Tasks.prototype.create_task = function (list_id, data) {
 	token = this.token;
 	return new Promise(async function (resolve, reject) {
 		try {

--- a/testes/Tasks/create_task.js
+++ b/testes/Tasks/create_task.js
@@ -11,7 +11,7 @@ async function main(){
 
 	try{
 
-		var info = await Clickup.Tasks.cretae_task("list_id", data);
+		var info = await Clickup.Tasks.create_task("list_id", data);
 		console.log(info);
 	}catch(err){
 		console.log(err)


### PR DESCRIPTION
Function for creating a task had the misspelling 'craete', this fixes that to 'create'.  Was using the library successfully and saw this.  Beautiful code by the way!