### PR TITLE
Update TimeTracking.js

### DIFF
--- a/src/components/TimeTracking.js
+++ b/src/components/TimeTracking.js
@@ -1,4 +1,5 @@
 const Requests = require("../utils/requests");
+const genParams = require("../utils/params");
 
 var TimeTracking = function (token) {
 	this.token = token;


### PR DESCRIPTION
The call to genParams fails for TimeTracking.prototype.get_time_entries_within_date_range as it has not been included in this module.